### PR TITLE
Disable turbolinks for language selector

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,6 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
-import "@hotwired/turbo-rails"
+import { Turbo } from "@hotwired/turbo-rails"
+
 import "controllers"
 
 // install bootstrap and dependencies
@@ -34,7 +35,6 @@ window.$ = jquery
 
 
 // Parallax effects for some images
-
 if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
   //Mobile
   window.addEventListener('deviceorientation', initFallback);
@@ -119,8 +119,8 @@ document.onreadystatechange = function() {
       this.updateTransformOrigin();
     },
   };
-  paperMenu.init();
-};
+
+paperMenu.init();
 
 // Home page - the changing text animation (writing)
 const elts = {
@@ -210,6 +210,7 @@ function animate() {
 }
 
 animate();
+};
 
 
 $(document).ready(function(){
@@ -219,7 +220,7 @@ $(document).ready(function(){
     localStorage.setItem('cookieSeen','shown')
   }
 
-  $('.banner-close').click(function(e) {
+  $('.close').click(function(e) {
     $('.cookie-banner').fadeOut();
   });
 });

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -10,7 +10,7 @@
     = render 'shared/favicons'
     = stylesheet_link_tag "application", "data-turbo-track": "reload"
     = javascript_importmap_tags
-  %body
+  %body{class: "#{controller_name} #{action_name}"}
     - flash.each do |type, msg|
       - if type == 'notice'
         .alert.alert-info

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -4,13 +4,14 @@
       %nav
         .close
           = navigation_items_html_safe
+      }
     #paper-window
       #paper-front
         .hamburger
           %span
         #container
           #navline.mobile
-          %section.start-section
+          %section.start-section{'data-turbo': "false"}
             = social_media_helper(animation: 'fa-flip', direction: 'vertical')
             = language_selection_html_safe
           %section.video-section#videos


### PR DESCRIPTION
Due to activated turbolinks, the switching of the language through the links in the navbar do not reload the js needed for the navbar menu to work. So, I needed to disable turbolinks for the navbar so that each language switch which causes the url to change, to reload the js. 